### PR TITLE
Quickfix likelihood drift

### DIFF
--- a/src/plots.R
+++ b/src/plots.R
@@ -232,8 +232,8 @@ show_ranking_history <- function(scores) {
     player_in_ranking <- unique(unlist(scores[scores[, "date"] <= d, c("joueur_A1", "joueur_A2", "joueur_B1", "joueur_B2")]))
     player_in_ranking <- player_in_ranking[!is.na(player_in_ranking)]
     if(d %in% as.character(drift_dates)) {
-      drifting_players <- sapply(as.character(drift_per_player), function(x) d %in% x)
-      players[player_in_ranking[name[drifting_players] %in% player_in_ranking]] <- lapply(players[player_in_ranking[name[drifting_players] %in% player_in_ranking]], drift)
+      drifting_players_today <- sapply(as.character(drift_per_player), function(x) d %in% x)
+      players[player_in_ranking[name[drifting_players_today] %in% player_in_ranking]] <- lapply(players[player_in_ranking[name[drifting_players_today] %in% player_in_ranking]], drift)
     }
     if(d %in% as.character(game_dates)) {
       players[player_in_ranking] <- update_scores(players=players[player_in_ranking], scores=scores[scores[, "date"] == d, ])

--- a/src/update_scores.R
+++ b/src/update_scores.R
@@ -180,10 +180,9 @@ posteriori_1vs1_vectorized <- function(distr_S1, distr_S2, game_len, win, date, 
   )
   
   Likelihood_fun1 <- function(p_win_1_pt) {
-    p1 <- p_win_exact(p_win_1_pt, scoreA, scoreB)
-    p2 <- p_win_exact(p_win_1_pt, scoreB, scoreA)
+    p <- p_win_exact(p_win_1_pt, scoreA, scoreB)
     
-    prod((p1 * win + p2 * (1 - win)))#^((0.5^(2 / 365))^as.numeric(Sys.Date() - date)))
+    prod(p)#^((0.5^(2 / 365))^as.numeric(Sys.Date() - date)))
   }
   
   Likelihood_fun2 <- function(p_win_1_pt) {


### PR DESCRIPTION
- renommer objet des noms de joueurs à drifter
- modification de la likelihood de la binomiale